### PR TITLE
add Required version of ruby and gem files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ https://chrome.google.com/webstore/detail/nezumi/jphlnepdpbnjmjlnbbcfmcnngnaagpm
 
 ![image](https://raw.githubusercontent.com/wiki/mugi-uno/nezumi/images/motion.gif)
 
+# Requirements on your rails application
+- Ruby 2.4.1 or higher
+
+# The list of gem files to use nezumi
+```
+  gem 'rails', '~> 5.1.4'
+  gem 'capybara'
+  gem 'poltergeist'
+  gem 'rspec-rails'
+```
+
 # Supported Actions
 
 - form edit


### PR DESCRIPTION
When we use nezumi as a tool of generating test code for Capybara/RSpec, it seems like that there are no description of requirements. 
added mention( ex. README ) about the list of requirements to use nezumi like this pull request , it would help us to use it easily. 

Thank you.